### PR TITLE
Fix: End Activity after start a new Activity

### DIFF
--- a/app/src/main/java/com/example/tapasrestaurant/MainActivity.kt
+++ b/app/src/main/java/com/example/tapasrestaurant/MainActivity.kt
@@ -22,6 +22,7 @@ class MainActivity : AppCompatActivity() {
         btnOpenActivity.setOnClickListener {
             val intent = Intent(this, SecondActivity::class.java)
             startActivity(intent)
+            finish()
         }
     }
 }

--- a/app/src/main/java/com/example/tapasrestaurant/SecondActivity.kt
+++ b/app/src/main/java/com/example/tapasrestaurant/SecondActivity.kt
@@ -14,6 +14,7 @@ class SecondActivity : Activity() {
         btnOpenActivity.setOnClickListener {
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
+            finish()
         }
     }
 }

--- a/app/src/main/java/com/example/tapasrestaurant/StartActivity.kt
+++ b/app/src/main/java/com/example/tapasrestaurant/StartActivity.kt
@@ -14,6 +14,7 @@ class StartActivity : AppCompatActivity() {
         btnStart.setOnClickListener {
             val intent = Intent(this, MainActivity::class.java)
             startActivity(intent)
+            finish()
         }
     }
 }


### PR DESCRIPTION
Before: If you open a new activity, you can always go back after you click a button
After: If you open a new activity, the app is going to the homescreen or where ever you was before outside the app